### PR TITLE
fix: Remove duplicate entry of scipy in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-scipy
 tqdm
 yacs
 Cython


### PR DESCRIPTION
In the requirements.txt is a duplicate entry of scipy one without version specification one with version higher than 1.4.1 requirement.

This pull request sets the requirements `scipy>=1.4.1`, and removes the duplicated entry.