### PR TITLE
Remove duplicated `scipy` requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-scipy
 tqdm
 yacs
 Cython


### PR DESCRIPTION
Remove duplicated `scipy` requirements that create bugs when installing the requirements:
```bash
ERROR: Double requirement given: scipy>=1.4.1 (from -r https://raw.githubusercontent.com/hustvl/YOLOP/main/requirements.txt (line 10)) (already in scipy (from -r https://raw.githubusercontent.com/hustvl/YOLOP/main/requirements.txt (line 1)), name='scipy')
```