### PR TITLE
Fix training_script for detector and encoder+detector only.

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -10,7 +10,7 @@ import torch
 import torch.nn.parallel
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.cuda import amp
-import torch.distributed as dist
+import torch.distributed as disthttps://github.com/ginofft/YOLOP.git
 import torch.backends.cudnn as cudnn
 import torch.optim
 import torch.utils.data
@@ -212,7 +212,7 @@ def main():
                     print('freezing %s' % k)
                     v.requires_grad = False
 
-        if cfg.TRAIN.ENC_DET_ONLY or cfg.TRAIN.DET_ONLY:    # Only train encoder and detection branchs
+        if cfg.TRAIN.ENC_DET_ONLY and cfg.TRAIN.DET_ONLY:    # Only train encoder and detection branchs
             logger.info('freeze two Seg heads...')
             for k, v in model.named_parameters():
                 v.requires_grad = True  # train all layers

--- a/tools/train.py
+++ b/tools/train.py
@@ -10,7 +10,7 @@ import torch
 import torch.nn.parallel
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.cuda import amp
-import torch.distributed as disthttps://github.com/ginofft/YOLOP.git
+import torch.distributed as dist
 import torch.backends.cudnn as cudnn
 import torch.optim
 import torch.utils.data


### PR DESCRIPTION
I noted that you cannot change Detector only in the demo training script, as the condition for "Encoder+Detector" would overwrite the previous config.

Btw, I know that you guys aint the one behind YoloPv2, but is there any plan to write a similar training script for it.
https://github.com/CAIC-AD/YOLOPv2