### PR TITLE
Fixed incorrect batch times during training (issue #128)

### DIFF
--- a/lib/core/function.py
+++ b/lib/core/function.py
@@ -47,10 +47,8 @@ def train(cfg, train_loader, model, criterion, optimizer, scaler, epoch, num_bat
 
     # switch to train mode
     model.train()
-    start = time.time()
     for i, (input, target, paths, shapes) in enumerate(train_loader):
-        intermediate = time.time()
-        #print('tims:{}'.format(intermediate-start))
+        start = time.time()
         num_iter = i + num_batch * (epoch - 1)
 
         if num_iter < num_warmup:


### PR DESCRIPTION
Start time of the batch processing should be initialized every time at the start of the loop, not outside as before. Also I removed the variable `intermediate` because it was never used.

fixes #128 